### PR TITLE
Add Bidi ribbon monitoring for HiTi P52x printers

### DIFF
--- a/MainApplication/MainApplication/MainWindow.xaml.cs
+++ b/MainApplication/MainApplication/MainWindow.xaml.cs
@@ -283,8 +283,8 @@ namespace MainApplication
         private void DefaultPrintErrorHandler(String errorMessage)
         {
             _havePrintError = true;
-            PrinterErrorDialog errorDialog = new PrinterErrorDialog(errorMessage);
-            
+            PrinterErrorDialog errorDialog = new PrinterErrorDialog(errorMessage, _printManager.RibbonMonitor);
+
             errorDialog.BringIntoView();
             errorDialog.ShowDialog();
 

--- a/MainApplication/MainApplication/PrinterErrorDialog.xaml.cs
+++ b/MainApplication/MainApplication/PrinterErrorDialog.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using Printing;
 
 namespace MainApplication
 {
@@ -25,13 +26,13 @@ namespace MainApplication
 
         private int _printCount;
         public int PrintCount {get{return _printCount;} }
-        
+
         public void ValidateInput()
         {
             Button_Ok.IsEnabled = _printCount > 0;
         }
-        
-        public PrinterErrorDialog(String printErrors)
+
+        public PrinterErrorDialog(String printErrors, RibbonMonitor ribbonMonitor = null)
         {
             InitializeComponent();
             Window.Topmost = true;
@@ -43,6 +44,18 @@ namespace MainApplication
             Label_printCount.Visibility = _needPrintCount ? Visibility.Visible : Visibility.Collapsed;
             Window.Title = _needPrintCount ? "OUT OF PAPER" : "Print Error";
             Window.Activate();
+
+            // Auto-fill the remaining count from the printer if Bidi is available
+            // (the operator may have already swapped in a fresh ribbon)
+            if (_needPrintCount && ribbonMonitor != null)
+            {
+                int? count = ribbonMonitor.GetRemainingPrints();
+                if (count.HasValue && count.Value > 0)
+                {
+                    _printCount = count.Value;
+                    TextBox_printCount.Text = count.Value.ToString();
+                }
+            }
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)

--- a/Printing/Printing/PrintManager.cs
+++ b/Printing/Printing/PrintManager.cs
@@ -27,6 +27,7 @@ namespace Printing
         private ManualResetEvent _doPrintSignal;
         private ManualResetEvent _killSignal;
         private Config _config;
+        private RibbonMonitor _ribbonMonitor;
 
         #region Construction
         private PrintManager(String name, Config config)
@@ -50,6 +51,8 @@ namespace Printing
                 }
 
                 _thisPrinter.Refresh();
+                _ribbonMonitor = new RibbonMonitor(_thisPrinter.FullName);
+                SyncRemainingPrintsFromPrinter();
 
                 while (!_killSignal.WaitOne(0))
                 {
@@ -75,6 +78,7 @@ namespace Printing
         public void Cleanup()
         {
             _killSignal.Set();
+            _ribbonMonitor?.Dispose();
         }
 
 
@@ -89,6 +93,8 @@ namespace Printing
         {
             _printErrorInformer = informer;
         }
+
+        public RibbonMonitor RibbonMonitor { get { return _ribbonMonitor; } }
 
         #endregion
 
@@ -202,7 +208,7 @@ namespace Printing
                         SaveRenderedTemplate(page);
                         _thisPrintBatch.RegisterSucessfullPrint();
 
-                        _config.RemainingPrints--;
+                        SyncRemainingPrintsFromPrinter(decrementFallback: true);
 
                         // Print the next page (eventually this should run out of batches or a print error will happen...)
                         Print();
@@ -265,10 +271,15 @@ namespace Printing
             {
                 statusReport = statusReport + "The printer is out of memory. ";
             }
+            SyncRemainingPrintsFromPrinter();
             if ((pq.QueueStatus & PrintQueueStatus.PaperOut) == PrintQueueStatus.PaperOut || _config.RemainingPrints <= 0)
             {
                 _config.RemainingPrints = 0;
                 statusReport = statusReport + "The printer is out of paper. ";
+            }
+            else if (_ribbonMonitor != null && _ribbonMonitor.IsLowOnRibbon())
+            {
+                statusReport = statusReport + $"Warning: only {_config.RemainingPrints} prints remaining on ribbon. ";
             }
             if ((pq.QueueStatus & PrintQueueStatus.OutputBinFull) == PrintQueueStatus.OutputBinFull)
             {
@@ -303,6 +314,19 @@ namespace Printing
         }
 
         #endregion
+
+        /// <summary>
+        /// Sync the remaining prints count from the printer via Bidi if available,
+        /// otherwise fall back to decrementing the manual counter.
+        /// </summary>
+        private void SyncRemainingPrintsFromPrinter(bool decrementFallback = false)
+        {
+            int? actual = _ribbonMonitor?.GetRemainingPrints();
+            if (actual.HasValue)
+                _config.RemainingPrints = actual.Value;
+            else if (decrementFallback)
+                _config.RemainingPrints--;
+        }
 
         private void InformClientOfPrintProblems(String problemDescription)
         {

--- a/Printing/Printing/Printing.csproj
+++ b/Printing/Printing/Printing.csproj
@@ -99,6 +99,7 @@
     </Compile>
     <Compile Include="NullPrintTemplate.cs" />
     <Compile Include="PrintManager.cs" />
+    <Compile Include="RibbonMonitor.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/Printing/Printing/RibbonMonitor.cs
+++ b/Printing/Printing/RibbonMonitor.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Printing
+{
+    /// <summary>
+    /// Queries the HiTi P52x printer for real ribbon status via the Windows Bidi interface.
+    /// Requires the P52xBidiLM.dll wrapper language monitor to be installed.
+    /// Falls back gracefully (returns null) when Bidi is not available.
+    /// </summary>
+    public class RibbonMonitor : IDisposable
+    {
+        private readonly string _printerName;
+        private dynamic _bidiSpl;
+        private bool _available;
+
+        public int LowRibbonThreshold { get; set; } = 10;
+
+        public RibbonMonitor(string printerName)
+        {
+            _printerName = printerName;
+            try
+            {
+                var bidiType = Type.GetTypeFromProgID("BidiSpl.BidiSpl");
+                if (bidiType == null)
+                {
+                    _available = false;
+                    return;
+                }
+                _bidiSpl = Activator.CreateInstance(bidiType);
+                _bidiSpl.BindDevice(_printerName);
+                _available = true;
+            }
+            catch
+            {
+                _available = false;
+            }
+        }
+
+        /// <summary>
+        /// Query the printer for actual remaining prints on the ribbon.
+        /// Returns null if Bidi is not available or the query fails.
+        /// </summary>
+        public int? GetRemainingPrints()
+        {
+            if (!_available) return null;
+            try
+            {
+                var reqType = Type.GetTypeFromProgID("BidiSpl.BidiRequest");
+                if (reqType == null) return null;
+                dynamic request = Activator.CreateInstance(reqType);
+                request.SetSchema(@"\Printer.Consumables.Ribbon:Remaining");
+                _bidiSpl.SendRecv(request);
+                return (int)request.GetResult();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public bool IsLowOnRibbon()
+        {
+            int? remaining = GetRemainingPrints();
+            return remaining.HasValue && remaining.Value <= LowRibbonThreshold;
+        }
+
+        public void Dispose()
+        {
+            try { _bidiSpl?.UnbindDevice(); } catch { }
+            if (_bidiSpl != null)
+            {
+                try { Marshal.ReleaseComObject(_bidiSpl); } catch { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `RibbonMonitor` class that queries the HiTi P52x printer for real remaining ribbon count via the Windows Bidi interface (`IBidiSpl` COM), replacing the manually-decremented counter
- Falls back gracefully to the existing manual `RemainingPrints` tracking when the Bidi driver extension is not installed or the printer doesn't support it
- Adds a low-ribbon early warning (default: 10 prints remaining) that triggers a print error before the ribbon is completely exhausted
- Auto-fills the remaining print count in the out-of-paper error dialog by querying the printer after a ribbon swap

## How it works

The `RibbonMonitor` uses the standard Windows `BidiSpl.BidiSpl` COM object to send a `\Printer.Consumables.Ribbon:Remaining` query to the printer driver. This requires the [P52xBidiLM.dll](https://github.com/mikebean233/Photo_Booth/tree/master) wrapper language monitor to be installed alongside the stock HiTi driver (see the `P52xL_Driver_v1.6.41.67/bidi/` directory for the driver patch).

When Bidi is unavailable (different printer, driver not patched, printer offline), all queries return `null` and the existing manual counter behavior is preserved — no functionality is lost.

## Changes

| File | Change |
|------|--------|
| `Printing/RibbonMonitor.cs` | **New** — Bidi client for ribbon status queries |
| `Printing/PrintManager.cs` | Sync remaining count from printer after each print and during error checks; expose `RibbonMonitor` property; add low-ribbon warning |
| `Printing/Printing.csproj` | Add `RibbonMonitor.cs` to compilation |
| `MainApplication/PrinterErrorDialog.xaml.cs` | Accept optional `RibbonMonitor` param; auto-fill count after ribbon swap |
| `MainApplication/MainWindow.xaml.cs` | Pass `RibbonMonitor` to error dialog |

## Test plan

- [ ] Verify the app builds and runs with no printer connected (Bidi unavailable path)
- [ ] Verify manual `RemainingPrints` counter still decrements when Bidi returns null
- [ ] With patched HiTi driver installed, verify `RibbonMonitor.GetRemainingPrints()` returns the real count
- [ ] Verify low-ribbon warning triggers when <= 10 prints remain
- [ ] Verify the error dialog auto-populates the count after a ribbon swap
- [ ] Verify out-of-paper detection still works when ribbon is fully exhausted

🤖 Generated with [Claude Code](https://claude.com/claude-code)